### PR TITLE
Add Volfied

### DIFF
--- a/PureDOSDAT.xml
+++ b/PureDOSDAT.xml
@@ -3846,6 +3846,56 @@
 		<rom name="SERSETUP.EXE" size="20257" crc="6f8c2806" md5="573d6f784c0ca293383b6737b2a8e2c5" sha1="c34e1d9bbfcdcd8868fb4141201d3d02473c0fe1" date="1995-05-25 01:09:10"/>
 		<rom name="SETUP.EXE" size="46665" crc="9a6be6d8" md5="729df5c0727cd290c1c34ffd29a04490" sha1="4664dbf04047a7b1733fed3654e6dd6b25b1613a" date="1995-05-25 01:09:10"/>
 	</game>
+	<game name="Volfied (1991) (Empire Software).dosz">
+		<description>Volfied</description>
+		<comment>Floppy dump of v2.0. Automatically selects highest compatible graphic and sound configurations. Also auto-runs without needing to set anything up.</comment>
+		<year>1991</year>
+		<developer>Empire Software</developer>
+		<rom name="01.RLE" size="18387" crc="2f554bd2" md5="3bfe4a192272da679626e1905fe9641a" sha1="739805730af0cc088da0c0d10c5a0b0764281dfe" date="1991-09-01 17:17:38"/>
+		<rom name="02.RLE" size="23355" crc="d049d9df" md5="61ff049a67d78354c5b8eb9542fbfce3" sha1="b07dfb88c844c0d5d664cc2055014e180362ecce" date="1991-09-01 17:18:06"/>
+		<rom name="03.RLE" size="21021" crc="4a7e3fe5" md5="68e2b09dd439c6210ad4d72527fe541c" sha1="90b88afc2758aa84609afde4b6550d5862e2f422" date="1991-12-05 11:48:32"/>
+		<rom name="04.RLE" size="23993" crc="48135626" md5="fb72002ad736ef2b2f8ed663689c75c8" sha1="a13550d524d09deb0546f42b6b25b5d3b5fbff9b" date="1991-12-05 11:49:04"/>
+		<rom name="05.RLE" size="19933" crc="3871a365" md5="8bfb43a06fbb76c85ea380c7a81ddeff" sha1="60987c24206957d798c947a1340b8b92053e4548" date="1991-09-01 17:19:16"/>
+		<rom name="06.RLE" size="22991" crc="b36d5dbc" md5="6fdbf902bf987e8417c6c8617fc6d2b9" sha1="1e954ec0293fbce40343511f29f2e9d33d5f3d5e" date="1991-09-01 17:19:56"/>
+		<rom name="07.RLE" size="18419" crc="917b39ae" md5="8d6555c887861f2d18a74cf270c47fb7" sha1="7af550a6aad19259a3b3fac53572d33616978fa9" date="1991-12-05 11:49:46"/>
+		<rom name="08.RLE" size="21500" crc="b833144f" md5="d2ca001cb91283cbb614e356d1caa535" sha1="1194f2d41bc4bead447cd39a8abfe8719d3f89ea" date="1991-09-01 17:20:42"/>
+		<rom name="09.RLE" size="23706" crc="c610f53b" md5="3851db88a4d3effc0053ce380e3de3ee" sha1="e6eb596aabab14313422176f2c2183ae2069757c" date="1991-09-01 17:21:08"/>
+		<rom name="10.RLE" size="21868" crc="f0e86b2a" md5="97d343fd7ed1b4800c0b63fd6d32f382" sha1="f1078acf94108b88a5bb37eda1c138d4cd5fd47d" date="1991-09-01 17:21:32"/>
+		<rom name="11.RLE" size="21613" crc="bd39cc49" md5="7de48024e7c1f7f0e62f774b329417e5" sha1="ff60e9cd0c6df1d04bc3aab430c15cb7e0b921a1" date="1991-12-05 11:50:14"/>
+		<rom name="12.RLE" size="19877" crc="43c60d9c" md5="b8168001afe3193c6ae8db4ab3eb1d53" sha1="03ad9f882794b4d9f93cec62a741fa18b3f063f6" date="1991-09-01 17:22:22"/>
+		<rom name="13.RLE" size="21977" crc="a4abd996" md5="fa218400503274bf1887ac426cb0ab1f" sha1="e9e93797f42be1cafd076f93d4fdb6ffd11fbdcf" date="1991-11-21 01:20:08"/>
+		<rom name="14.RLE" size="19708" crc="d2855b96" md5="79a91817f928a6e0a3cf66d58de70b85" sha1="bfa2df4dfbe0f00c103af4885828411c59c05c72" date="1991-09-01 17:23:08"/>
+		<rom name="15.RLE" size="21956" crc="9fee9eed" md5="9a876bda9feeff0256f5a189aa438e6f" sha1="7d78cf20a3a494ea7657bb20ea2785f3888494d9" date="1991-09-01 17:23:30"/>
+		<rom name="16.RLE" size="18432" crc="54a2b29f" md5="60517cdd164a7e2ef205288563b5f969" sha1="d5061cd2a1b36c1f5ea895895c33c07f80cfcc1e" date="1991-11-25 17:27:14"/>
+		<rom name="99.RLE" size="19320" crc="741fc1ba" md5="11711c066cb9adefa9a42e9e9c273264" sha1="a028ae4660caecbb8543833e4c67a56bc6d04a11" date="1991-11-25 16:04:22"/>
+		<rom name="_00.RLE" size="34341" crc="5d284bed" md5="a7ab7d6c526ea3b4f53203c554f1bfdc" sha1="0ced34e775675bc5ef56783e0f283c7564f6de74" date="1991-12-02 00:38:22"/>
+		<rom name="_01.RLE" size="5634" crc="43d7a7e2" md5="c004b5367ffe92031a8ebca6afd0046c" sha1="db4cabc0de35c4d4fd5fbddf7ac80118549de442" date="1991-12-03 04:07:30"/>
+		<rom name="_99.RLE" size="21738" crc="20dfaf16" md5="56db4b33617473792f75c2095db09cf6" sha1="7f466ccceccab81119d7dd251d38c3a4f91e7250" date="1991-12-03 16:50:16"/>
+		<rom name="ADLIB.BIN" size="4127" crc="17198536" md5="5469f65f100622f146e1fda8e4fc690d" sha1="47045166ae7842528fcacdb55a6dcd0d7cede551" date="1991-10-24 14:53:56"/>
+		<rom name="BEEPER.BIN" size="4119" crc="b5a06c88" md5="45960e296deee3e1e3aa81f440e337ee" sha1="fa1df7973137fb54b4f9b93fb2d9bf3fe1a57771" date="1991-11-06 18:33:22"/>
+		<rom name="CGA.PRG" size="40361" crc="afa72d04" md5="dc061c3746fc64842eca5c3891bf0856" sha1="a3ff7369c3478a1eb0d5496d2c307a65ff49d17d" date="1991-12-05 15:01:16"/>
+		<rom name="EGA.PRG" size="38495" crc="197d2816" md5="ea8548414167f1edf423d6ce077a224c" sha1="74dea3bd50c634ad925368e8cc60e4a9727624c9" date="1991-12-05 15:02:34"/>
+		<rom name="R01.RLE" size="16393" crc="94eda76d" md5="e1d2be7f8f32daf4e3eea11caca7969c" sha1="bdd9fc3e741d5e4cfb5bf2c4a3d2906771c8e346" date="1991-11-02 03:24:04"/>
+		<rom name="R02.RLE" size="7125" crc="aec11e8b" md5="c06407a6d59388f4c972ff98c52adc9e" sha1="73228c7127912e02717a3e04654f1d2fca5b120e" date="1991-11-02 03:27:02"/>
+		<rom name="R03.RLE" size="4237" crc="669047cf" md5="9de6bdbcc8598a3355e0e616360819bb" sha1="aaa45a9aeaf46428eaf2dc16a136d5c3342ec7fc" date="1991-11-05 01:27:30"/>
+		<rom name="R04.RLE" size="4336" crc="e2ad1e96" md5="41a609a0d480688109e7d0e5180bb4d6" sha1="21d2ff750dca07d8356b55c7954da199fab2394b" date="1991-11-14 15:30:24"/>
+		<rom name="R05.RLE" size="17593" crc="68c15728" md5="dcb15153d621b2e4cfa0fd710968f4e4" sha1="76db6f878f50d0be238db0fe829177deec6a2ce2" date="1991-11-15 04:07:36"/>
+		<rom name="R06.RLE" size="2265" crc="618df82c" md5="c5100f65e38d520d1e0305911c2ab301" sha1="325ee834561ffa3561ebc16263e99f071380a915" date="1991-11-13 17:01:12"/>
+		<rom name="R07.RLE" size="11491" crc="cdc23338" md5="c296cb1f6ccb16f1c98fff9eb2b1d72b" sha1="e0c6ccbf534afb607e8c23c21fa6adf7d71d41ac" date="1991-11-19 09:42:48"/>
+		<rom name="R08.RLE" size="8276" crc="18d46f5c" md5="790da8beb2a59c4d057e1838fa9c6fe9" sha1="0530e7be992a11e2b06939eb544f7bc698fd7e7d" date="1991-11-02 08:43:40"/>
+		<rom name="R09.RLE" size="7358" crc="bdabf21c" md5="42cd45819e122f72c9167940909bad5b" sha1="243cba7ba802fc3955c8fae81b16573c91e25edf" date="1991-11-05 06:04:36"/>
+		<rom name="R10.RLE" size="2791" crc="500e0cb3" md5="c5643594e632ad62a75f661d269e9851" sha1="521ef8b7573d264744c4d9b634e5f089e48f074c" date="1991-11-03 03:28:08"/>
+		<rom name="R11.RLE" size="2685" crc="79ae5c33" md5="26b857bfe919d7c68ad710060f9b7cf0" sha1="796075fbd2a2bbd7800edadc9e79fd4d99a58e98" date="1991-11-13 19:29:56"/>
+		<rom name="R12.RLE" size="4495" crc="bcbc76fb" md5="dd511fd154bc793a60c526f51f9b0857" sha1="7dba4979b04585bb1f0079d46b267d3d768898db" date="1991-11-25 03:30:56"/>
+		<rom name="R13.RLE" size="3030" crc="53da9105" md5="8eb607fddc5f5e295d4a327966be1e69" sha1="a8c808c612723b43ec941f8dff70018750663993" date="1991-11-21 09:46:58"/>
+		<rom name="R15.RLE" size="11803" crc="e1710a85" md5="c66102bcc894f5f154d0d95df47048b8" sha1="dfa6f833ce36e3ebf9b9371d369e0865bf250973" date="1991-11-02 19:10:32"/>
+		<rom name="R16.RLE" size="5474" crc="e92c0f72" md5="e31f0bfacb00082185c241b615938b96" sha1="2e49138712e3d2edfa90365c45c13b30942090b5" date="1991-11-25 16:17:12"/>
+		<rom name="README.DOC" size="1797" crc="30467bee" md5="4746c27ef9cb2409593881fd2ad6bfee" sha1="ed3e1250e52b586e2a792b1141664305045dc960" date="1991-12-05 11:18:08"/>
+		<rom name="TANDY.BIN" size="3918" crc="9b10682c" md5="58014cafebcf7c656781bea7fe866418" sha1="3469f151af639baa4548ac3d2359465c3c067cb5" date="1991-11-06 17:31:54"/>
+		<rom name="TGA.PRG" size="36533" crc="07ed73fa" md5="e70193d779962a8b7abc611acab3fd96" sha1="71b5394c3c39c45b0855dd79e61f6a2e78af7bfb" date="1991-12-05 15:05:16"/>
+		<rom name="VGA.PRG" size="38837" crc="e3dc1a6f" md5="73caab080f6e99d71a6cc358b1ecaab3" sha1="dd24c8a7de5dc22d38ecf5056c7b7f61b0f40d78" date="1991-12-05 15:03:54"/>
+		<rom name="VOLFIED.EXE" size="2877" crc="414bf40a" md5="685597e4c6d965073bbc7e0c7d759c70" sha1="b3f0fa91f97e760f48efc3fe844fcfcd7e44b750" date="1991-12-05 13:57:36"/>
+	</game>
 	<game name="Warcraft - Orcs &amp; Humans (1994) (Blizzard Entertainment).dosz">
 		<description>Warcraft - Orcs &amp; Humans</description>
 		<comment>Installed v1.22h from CD re-release from 1996</comment>


### PR DESCRIPTION
Floppy dump of v2.0. Automatically selects highest compatible graphic and sound configurations. Also auto-runs without needing to set anything up.